### PR TITLE
add extended configuration and remote monitoring API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,25 @@ Then install the dependencies:
 
 There is a file called `config.json` in the application directory. You should modify it to list the IP addresses of the AirPlay speakers you wish to broadcast to. You can also set the name of the group in the config file.
 
-The config file looks like this:
+A minimal config file looks like this:
 
 ```json
 {
 	"groupName": "All Speakers",
-	"endpoints": [
-		"192.168.1.116",
-		"192.168.1.117"
-	]
+	"endpoints": {
+		"kitchen": {
+			"host": "192.168.1.116",
+			"enabled": true
+		},
+		"living-room": {
+			"host": "192.168.1.117",
+			"enabled": true
+		}
+	}
 }
 ```
+
+See below for a full example with all options.
 
 ### Starting the server
 Just run:
@@ -46,10 +54,72 @@ Just run:
 ### Connect and play!
 If your server and iOS device are on the same network, you should see a new AirPlay target called "All Speakers", or whatever you named your group in the `config.json`. Select that AirPlay target and start playing!
 
-##To-Do
+## Advanced Configuration
+The main part of the configuration is a list of endpoints, i.e. the Airplay speakers.
+Each speaker has a name as key, which is also used as identifier in the remote control API.
+The speaker configuration consists of:
+
+- **host**: Hostname or IP-address of the Airplay speaker (required)
+- **options**: Options object passed to *airtunes* (optional)
+- **powerOnRequest**: Request sent before starting to stream. Automatic wake-up from sleep does not work reliably with airtunes, so a manual wake-up is recommended. The value is a [node request](https://www.npmjs.com/package/request) object. Below example shows the power-on request of a Yamaha MusicCast WX-030 for kitchen and the power-on command for a Yamaha AVR in living room (optional)
+- **powerOffRequest**: Just like `powerOnCommand`, but sent after the server disconnects from a speaker. (optional)
+- **enabled**: By default, all speakers are disconnected and require explicit enablement via the remote-control API. If `enabled` is set to true, then the speakers are enabled by default without doing an API call first. (optional)
+
+```
+{
+	"groupName": "All Speakers",
+	"endpoints": {
+		"kitchen": {
+			"host": "192.168.1.116",
+			"powerOnRequest": {
+				"url": "http://192.168.1.116/YamahaExtendedControl/v1/main/setPower?power=on"
+			},
+			"powerOffRequest": {
+				"url": "http://192.168.1.116/YamahaExtendedControl/v1/main/setPower?power=standby"
+			}
+		},
+		"living-room": {
+			"host": "192.168.1.117",
+			"options": {
+				"port": 1028
+			},
+			"powerOnRequest": {
+				"url": "http://192.168.1.117/YamahaRemoteControl/ctrl",
+				"method": "POST",
+				"headers": {
+					"Content-Type": "application/xml"
+				},
+ 				"body": "<YAMAHA_AV cmd=\"PUT\"><Main_Zone><Power_Control><Power>On</Power></Power_Control></Main_Zone></YAMAHA_AV>"
+			},
+			"powerOffRequest": {
+				"url": "http://192.168.1.53/YamahaRemoteControl/ctrl",
+				"method": "POST",
+				"headers": {
+					"Content-Type": "application/xml"
+				},
+ 				"body": "<YAMAHA_AV cmd='PUT'><Main_Zone><Power_Control><Power>Standby</Power></Power_Control></Main_Zone></YAMAHA_AV>"
+			}
+		}
+	}
+}
+```
+
+## Remote control API
+Shaircast exposes an API on port `5010` to enable or disable speakers and to retrieve the current status.
+
+- `http://localhost:5010/speakers/kitchen`: returns the `enabled`-status of the speaker
+- `http://localhost:5010/speakers/kitchen/enable`: enables the speaker with name `kitchen`. Audio steam will be forwarded to this speaker.
+- `http://localhost:5010/speakers/kitchen/disable`: disables the speaker with name `kitchen`. Audio streaming to this speaker stops immediately.
+
+
+## To-Do
 This is very early still, and there are a few enhancements I would like to make such as:
  - Optimizing network performance over Wi-Fi (reduce audio dropouts)
  - Enabling multiple groups
  - Installation via `npm` and command line
 
 Please feel free to provide other suggestions, or report bugs on GitHub.
+
+## Troubleshooting
+### Installation is failing due to *fatal error: alsa/asoundlib.h: No such file or directory*
+`sudo apt-get install libasound2-dev`

--- a/airplay-splitter.js
+++ b/airplay-splitter.js
@@ -1,0 +1,128 @@
+var airtunes = require("airtunes");
+var rp = require('request-promise');
+var Promise = require("bluebird");
+
+function AirplaySplitter(speakers) {
+		this.speakers = speakers;
+		this.devices = {};
+		this.currentStream;
+}
+
+AirplaySplitter.prototype.speaker = function(name) {
+	if (!this.speakers[name]) {
+		throw "Speaker '" + name + "' is not configured.";
+	}
+
+	return this.speakers[name];
+}
+
+AirplaySplitter.prototype.enableSpeaker = function(name) {
+	console.log("Enabling speaker " + name);
+	this.speaker(name).enabled = true;
+	if (this.isStreaming()) {
+		this.connectSpeaker(name);
+	}
+}
+
+AirplaySplitter.prototype.disableSpeaker = function(name) {
+	console.log("Disabling speaker " + name);
+	this.speaker(name).enabled = false;
+	if (this.isStreaming()) {
+		this.disconnectSpeaker(name);
+	}
+}
+
+AirplaySplitter.prototype.isSpeakerEnabled = function(name) {
+	return !!this.speaker(name).enabled;
+}
+
+AirplaySplitter.prototype.connectSpeaker = function(name) {
+	console.log("Connecting speaker " + name);
+
+	var self = this;
+	var speaker = this.speaker(name);
+	console.log("Adding " + name + " (" + speaker.host + ")");
+
+  var powerOn = (speaker.powerOnRequest ? rp(speaker.powerOnRequest) : Promise.resolve());
+
+	powerOn.then(function() {
+		self.devices[name] = airtunes.add(speaker.host, speaker.options);
+	}).catch(function(error) {
+		throw "Power on of " + name + " failed with " + error;
+	});
+}
+
+AirplaySplitter.prototype.disconnectSpeaker = function(name) {
+	if (this.devices[name]) {
+		console.log("Disconnecting speaker " + name);
+
+		this.devices[name].stop(function() {
+			console.log("Device " + name + " stopped");
+		});
+
+		delete this.devices[name];
+
+		if (this.devices[name].powerOffRequest) {
+			rp(speaker.powerOffRequest).catch(function(error) {
+				// Power off error is not a severe. Will go to standby at some point
+				console.log("Power off failed with " + error);
+			});
+		}
+	} else {
+		console.log("Speaker " + name + " is not connected");
+	}
+}
+
+AirplaySplitter.prototype.isStreaming = function() {
+	return !!this.currentStream;
+}
+
+AirplaySplitter.prototype.startStreaming = function(stream) {
+	console.log("Starting streaming");
+	if (this.isStreaming()) {
+		console.log("Already streaming. Stop that first.");
+		this.stopStreaming();
+	}
+
+	this.devices = {};
+
+	for (var name in this.speakers) {
+		var speaker = this.speaker(name);
+		if (speaker.enabled) {
+			this.connectSpeaker(name);
+		}
+	}
+
+	this.currentStream = stream;
+	stream.pipe(airtunes);
+}
+
+AirplaySplitter.prototype.stopStreaming = function() {
+	console.log("Stopping streaming");
+
+	this.currentStream.unpipe();
+	airtunes.stopAll(function() {
+		console.log("All devices stopped")
+	});
+
+	this.devices = {};
+	this.currentStream = null;
+}
+
+AirplaySplitter.prototype.setVolume = function(volume) {
+	volume = (volume + 30) / 30 * 100
+	console.log("Changing volume to " + volume);
+	for (var key in this.devices) {
+		this.devices[key].setVolume(volume);
+	}
+}
+
+AirplaySplitter.prototype.updateMetadata = function(title, artist, album) {
+	console.log("Now playing \"" + title + "\" by " + artist + " from \"" + album + "\"");
+
+	for (var key in this.devices) {
+		this.devices[key].setTrackInfo(title, artist, album);
+	}
+}
+
+module.exports = AirplaySplitter;

--- a/config.json
+++ b/config.json
@@ -1,7 +1,13 @@
 {
 	"groupName": "All Speakers",
-	"endpoints": [
-		"192.168.1.116",
-		"192.168.1.117"
-	]
+	"endpoints": {
+		"kitchen": {
+			"host": "192.168.1.116",
+			"enabled": true
+		},
+		"living-room": {
+			"host": "192.168.1.117",
+			"enabled": true
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,17 @@
   "description": "So your iPhone can play music all around your house",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "scan": "node ./node_modules/airtunes/examples/scan_airtunes.js"
   },
   "author": "Nicko Guyer",
   "license": "MIT",
   "dependencies": {
     "airtunes": "^0.1.7",
-    "nodetunes": "^0.1.2",
-    "speaker": "^0.2.5"
+    "bluebird": "^3.5.0",
+    "express": "^4.15.4",
+    "nodetunes": "^0.3.0",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1",
+    "speaker": "^0.3.0"
   }
 }


### PR DESCRIPTION
This PR adds:
- advanced configuration with
  - named endpoints
  - `airtunes` options
  - power-on/off requests
- remote control API
  - enable/disable speakers while the server is running and even while a audio is streaming

The idea behind this change is to integrate ShairCast in Openhab as a Multiroom Audio solution and it's working great. Speakers can be enabled/disabled how I like and the stream is just playing in perfect sync.
The only real big issue are the sound dropouts, making it pretty much unusable. I did some testing and to me it looks like performance is the problem. It's working without significant dropouts on my Macbook Pro, but on an Raspberry PI 3 connected through Ethernet I get dropouts every few seconds.